### PR TITLE
Add support for Buddhist Calendar

### DIFF
--- a/lib/calendar/TableDate.tsx
+++ b/lib/calendar/TableDate.tsx
@@ -46,7 +46,11 @@ export function TableDate({
   const dates = chunk(getCalendar({ firstDayOfWeek, year, month }), 7);
 
   const formatDate = (date: Date, fmt: string) => {
-    return format(date, fmt, { locale: locale.formatLocale });
+    if (locale.buddhistYear && fmt == 'YYYY') {
+      return '' + (parseInt(format(date, fmt, { locale: locale.formatLocale })) + 543);
+    } else {
+      return format(date, fmt, { locale: locale.formatLocale });
+    }
   };
 
   const handlePanelChange = (panel: 'year' | 'month') => {

--- a/lib/calendar/TableMonth.tsx
+++ b/lib/calendar/TableMonth.tsx
@@ -38,7 +38,7 @@ export function TableMonth({
           class={`${prefixClass}-btn ${prefixClass}-btn-text ${prefixClass}-btn-current-year`}
           onClick={() => onUpdatePanel('year')}
         >
-          {calendar.getFullYear()}
+          {locale.buddhistYear ? 543 + calendar.getFullYear() : calendar.getFullYear()}
         </button>
       </TableHeader>
       <div class={`${prefixClass}-calendar-content`}>

--- a/lib/calendar/TableYear.tsx
+++ b/lib/calendar/TableYear.tsx
@@ -1,4 +1,4 @@
-import { usePrefixClass } from '../context';
+import { usePrefixClass, useLocale } from '../context';
 import { chunk, last } from '../util/base';
 import { createDate } from '../util/date';
 import { TableHeader, TableHeaderProps } from './TableHeader';
@@ -25,6 +25,7 @@ export function TableYear({
   onUpdateCalendar,
 }: TableYearProps) {
   const prefixClass = usePrefixClass();
+  const locale = useLocale().value;
 
   const getDate = (year: number) => {
     return createDate(year, 0);
@@ -37,8 +38,8 @@ export function TableYear({
   };
 
   const years = getYearPanel(new Date(calendar));
-  const firstYear = years[0][0];
-  const lastYear = last(last(years));
+  const firstYear = locale.buddhistYear ? 543 + years[0][0] : years[0][0];
+  const lastYear = locale.buddhistYear ? 543 + (last(last(years)) ?? 0) : last(last(years));
 
   return (
     <div class={`${prefixClass}-calendar ${prefixClass}-calendar-panel-year`}>
@@ -58,7 +59,7 @@ export function TableYear({
                   data-year={cell}
                   onClick={handleClick}
                 >
-                  <div>{cell}</div>
+                  <div>{locale.buddhistYear ? 543 + cell : cell}</div>
                 </td>
               ))}
             </tr>

--- a/lib/locale/th.ts
+++ b/lib/locale/th.ts
@@ -6,6 +6,7 @@ const lang = {
   yearFormat: 'YYYY',
   monthFormat: 'MMM',
   monthBeforeYear: true,
+  buddhistYear: true,
 };
 
 DatePicker.locale('th', lang);

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -12,6 +12,8 @@ export interface Locale {
   monthFormat: string;
   // the calendar title of month before year
   monthBeforeYear: boolean;
+  // the calendar show year format as Buddhist calendar (AD + 543)
+  buddhistYear: boolean;
 }
 
 export type PlainObject = Record<string, any>;


### PR DESCRIPTION
add support for [Buddhist Calendar](https://en.wikipedia.org/wiki/Buddhist_calendar), used in Cambodia, Laos, Myanmar, India, Sri Lanka, and Thailand

Buddhist Calendar is equal to Common Era Year + 543
mean 2022 CE = 2565 BE

this commit create new boolean name : buddhistYear 
if buddhistYear  is true, year panel convert from CE to BE