### PR TITLE
fix: Prevent DatePicker time input from resetting date to today

### DIFF
--- a/lib/Picker.tsx
+++ b/lib/Picker.tsx
@@ -89,12 +89,12 @@ function Picker(originalProps: PickerProps, { slots }: SetupContext) {
     return format(date, fmt, { locale: locale.value.formatLocale });
   };
 
-  const parseDate = (value: string, fmt?: string): Date => {
+  const parseDate = (value: string, fmt?: string, defaultDate?: Date): Date => {
     fmt = fmt || props.format;
     if (isPlainObject(props.formatter) && typeof props.formatter.parse === 'function') {
       return props.formatter.parse(value, fmt);
     }
-    const backupDate = new Date();
+    const backupDate = defaultDate || new Date();
     return parse(value, fmt, { locale: locale.value.formatLocale, backupDate });
   };
 

--- a/lib/PickerInput.tsx
+++ b/lib/PickerInput.tsx
@@ -24,7 +24,7 @@ export interface PickerInputBaseProps {
 export interface PickerInputProps extends PickerInputBaseProps {
   value: Date | Date[];
   formatDate: (v: Date) => string;
-  parseDate: (v: string) => Date;
+  parseDate: (v: string, fmt?: string, defaultDate?: Date) => Date;
   disabledDate: (v: Date) => boolean;
   onChange: (v: Date | Date[] | null | null[]) => void;
   onFocus: () => void;
@@ -109,7 +109,7 @@ function PickerInput(originalProps: PickerInputProps, { slots }: SetupContext) {
     } else if (props.multiple) {
       date = text.split(innerSeparator.value).map((v) => props.parseDate(v.trim()));
     } else {
-      date = props.parseDate(text);
+      date = props.parseDate(text, undefined, props.value as Date);
     }
     if (isValidValue(date) && !isDisabledValue(date)) {
       props.onChange(date);


### PR DESCRIPTION
### PR Description

#### **Problem Encountered:**  
When assigning a specific date (e.g., `value = new Date('2025-02-14')`), manually entering a value in a `type="time"` `<DatePicker>` component causes the date to reset to today's date.  

##### **Reproduction Example:**  
```vue
<DatePicker v-model:value="value" type="date"></DatePicker> 
<DatePicker v-model:value="value" type="time" format="HH:mm"></DatePicker>
```  
- **Expected:** The time input should update only the time while preserving the original date (`2025-02-14`).  
- **Actual:** The date is reset to today (`new Date()`).  

#### **Solution in This PR:**  
- In `PickerInput`, when `handleChange` is triggered, we retain the original date while updating only the time.  
- Instead of using `parseDate`, which resets the date to today, we ensure that only the time portion is modified.  
- This prevents unexpected date resets and ensures consistent behavior across `type="time"` inputs.
